### PR TITLE
Rename db

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ After cloning the project, we will create the local database that the project wi
 ## Database
 
 - Open the terminal, and `cd` into `server`
-- Create your database: `createdb final_project`
+- Create your database: `createdb final_project_phamy`
 - `npm run recreate-db:local` (this will create and populate your new team's DB with the data your colleague added)
 
 > Your actual database schema will go to `server/db/recreate-schema.sql` and you can add sample test data in `server/db/populate-db.sql`

--- a/server/config.js
+++ b/server/config.js
@@ -2,7 +2,7 @@ const config = {
   development: {
     user: "app_user",
     host: "localhost",
-    database: "final_project",
+    database: "final_project_phamy",
     password: "password",
     port: 5432
   },


### PR DESCRIPTION
Renames the project database from final_project to final_project_phamy. This is to make it easier for mentors or anyone else who want to run more than one graduation project on the same host.